### PR TITLE
Page all the lists

### DIFF
--- a/Api.Client.Tests/DataSetIntegrationTests.cs
+++ b/Api.Client.Tests/DataSetIntegrationTests.cs
@@ -159,6 +159,14 @@ namespace Api.Client.Tests
         }
 
         [Fact]
+        public async Task ListRespectPageingInfo()
+        {
+            var list = await fixture.Client.DataSets.List(1, 1);
+            Assert.Equal(1, list.Count);
+            Assert.Equal(1, (list as PagedList<DataSetSummary>).PageNumber);
+        }
+
+        [Fact]
         public async Task CanRemoveDataSet()
         {
             var id = Guid.NewGuid().ToString("N");

--- a/Api.Client.Tests/DataSetIntegrationTests.cs
+++ b/Api.Client.Tests/DataSetIntegrationTests.cs
@@ -113,10 +113,10 @@ namespace Api.Client.Tests
         {
             var result = await fixture.Client.DataSets.Get(fixture.ForecastDataSetName);
 
-            Assert.Equal(1, result.Links.Count);
-            Assert.Equal(new [] { "sessions"}, result.Links.Select(l => l.Rel));
+            Assert.Equal(4, result.Links.Count);
+            Assert.Equal(new [] { "self", "sessions", "first", "last"}, result.Links.Select(l => l.Rel));
             
-            Assert.Equal($"{fixture.Client.ConfiguredUrl}sessions?dataSourceName={fixture.ForecastDataSetName}", result.Links[0].Href);
+            Assert.Equal($"{fixture.Client.ConfiguredUrl}sessions?dataSourceName={fixture.ForecastDataSetName}", result.Links[1].Href);
         }
 
         [Fact]

--- a/Api.Client.Tests/DataSetTests/ListTests.cs
+++ b/Api.Client.Tests/DataSetTests/ListTests.cs
@@ -17,7 +17,7 @@ namespace Api.Client.Tests.DataSetTests
             var result = await target.DataSets.List();
 
             Assert.Equal(HttpMethod.Get, handler.Request.Method);
-            Assert.Equal(new Uri(baseUri, "data"), handler.Request.RequestUri);
+            Assert.Equal(new Uri(baseUri, "data?page=0&pageSize=50"), handler.Request.RequestUri);
         }
 
         [Fact]
@@ -26,7 +26,7 @@ namespace Api.Client.Tests.DataSetTests
             var result = await target.DataSets.List("partialSomething");
 
             Assert.Equal(HttpMethod.Get, handler.Request.Method);
-            Assert.Equal(new Uri(baseUri, "data?partialName=partialSomething"), handler.Request.RequestUri);
+            Assert.Equal(new Uri(baseUri, "data?partialName=partialSomething&page=0&pageSize=50"), handler.Request.RequestUri);
         }
     }
 }

--- a/Api.Client.Tests/ImportIntegrationTests.cs
+++ b/Api.Client.Tests/ImportIntegrationTests.cs
@@ -20,8 +20,15 @@ namespace Api.Client.Tests
         {
             var response = await fixture.Client.Imports.ImportFromS3("s3-import-locationa", "nexosis-sample-data",
                 "LocationA.csv", "us-east-1");
-            
+
             Assert.NotEqual(Guid.Empty, response.ImportId);
+        }
+
+        [Fact]
+        public async Task ListRespectsPageSize()
+        {
+            var response = await fixture.Client.Imports.List(pageNumber: 0, pageSize: 1);
+            Assert.Equal(1, response.Count);
         }
     }
 #endif

--- a/Api.Client.Tests/ImportTests/ListTests.cs
+++ b/Api.Client.Tests/ImportTests/ListTests.cs
@@ -22,7 +22,7 @@ namespace Api.Client.Tests.ImportTests
         {
             var result = await target.Imports.List();
             Assert.Equal(HttpMethod.Get, handler.Request.Method);
-            Assert.Equal(new Uri(@"https://nada.nexosis.com/imports"), handler.Request.RequestUri);
+            Assert.Equal(new Uri(@"https://nada.nexosis.com/imports?page=0&pageSize=50"), handler.Request.RequestUri);
         }
 
         [Fact]
@@ -31,7 +31,7 @@ namespace Api.Client.Tests.ImportTests
             var result = await target.Imports.List("foo", DateTimeOffset.Parse("2017-01-01 0:00 -0:00"),
                 DateTimeOffset.Parse("2017-01-02 0:00 -0:00"));
 
-            Assert.Equal(new Uri(@"https://nada.nexosis.com/imports?dataSetName=foo&requestedAfterDate=2017-01-01T00:00:00.0000000%2B00:00&requestedBeforeDate=2017-01-02T00:00:00.0000000%2B00:00"), handler.Request.RequestUri);
+            Assert.Equal(new Uri(@"https://nada.nexosis.com/imports?dataSetName=foo&requestedAfterDate=2017-01-01T00:00:00.0000000%2B00:00&requestedBeforeDate=2017-01-02T00:00:00.0000000%2B00:00&page=0&pageSize=50"), handler.Request.RequestUri);
         }
     }
 }

--- a/Api.Client.Tests/ModelIntegrationTests.cs
+++ b/Api.Client.Tests/ModelIntegrationTests.cs
@@ -73,6 +73,16 @@ namespace Api.Client.Tests
         }
 
         [Fact]
+        public async Task ListRespectsPagingInfo()
+        {
+            var models = await fixture.Client.Models.List(1, 2);
+            var actual = models as PagedList<ModelSummary>;
+            Assert.NotNull(actual);
+            Assert.Equal(1, actual.PageNumber);
+            Assert.Equal(2, actual.PageSize);
+        }
+
+        [Fact]
         public async Task GetModelDetailsHasResults()
         {
             var result = await fixture.Client.Models.Get(savedModel.ModelId);

--- a/Api.Client.Tests/ModelsTests/ListTests.cs
+++ b/Api.Client.Tests/ModelsTests/ListTests.cs
@@ -23,7 +23,7 @@ namespace Api.Client.Tests.ModelsTests
             var result = await target.Models.List();
 
             Assert.Equal(HttpMethod.Get, handler.Request.Method);
-            Assert.Equal(new Uri(baseUri, "models"), handler.Request.RequestUri);
+            Assert.Equal(new Uri(baseUri, "models?page=0&pageSize=50"), handler.Request.RequestUri);
         }
 
         [Fact]
@@ -32,7 +32,7 @@ namespace Api.Client.Tests.ModelsTests
             var result = await target.Models.List("data-source-name", DateTimeOffset.Parse("2017-01-01 0:00 -0:00"), DateTimeOffset.Parse("2017-01-11 0:00 -0:00"));
 
             Assert.NotNull(result);
-            Assert.Equal(new Uri(baseUri, "models?dataSourceName=data-source-name&createdAfterDate=2017-01-01T00:00:00.0000000%2B00:00&createdBeforeDate=2017-01-11T00:00:00.0000000%2B00:00"), handler.Request.RequestUri);
+            Assert.Equal(new Uri(baseUri, "models?dataSourceName=data-source-name&createdAfterDate=2017-01-01T00:00:00.0000000%2B00:00&createdBeforeDate=2017-01-11T00:00:00.0000000%2B00:00&page=0&pageSize=50"), handler.Request.RequestUri);
         }
 
         [Fact]

--- a/Api.Client.Tests/SessionIntegrationTests.cs
+++ b/Api.Client.Tests/SessionIntegrationTests.cs
@@ -146,7 +146,7 @@ namespace Api.Client.Tests
         [Fact]
         public async Task GetSessionResultsHasLinks()
         {
-            var result = await fixture.Client.Sessions.GetResults(savedSession.SessionId);
+            var result = await fixture.Client.Sessions.Get(savedSession.SessionId);
             Assert.NotNull(result);
             Assert.Equal(2, result.Links.Count);
             Assert.Equal(new[] { "results", "data" }, result.Links.Select(l => l.Rel));

--- a/Api.Client.Tests/SessionIntegrationTests.cs
+++ b/Api.Client.Tests/SessionIntegrationTests.cs
@@ -134,6 +134,16 @@ namespace Api.Client.Tests
         }
 
         [Fact]
+        public async Task GetSessionListRespectsPagingInfo()
+        {
+            var sessions = await fixture.Client.Sessions.List(1, 2);
+            var actual = sessions as PagedList<SessionResponse>;
+            Assert.NotNull(actual);
+            Assert.Equal(1, actual.PageNumber);
+            Assert.Equal(2, actual.PageSize);
+        }
+
+        [Fact]
         public async Task GetSessionResultsHasResults()
         {
             var results = await fixture.Client.Sessions.GetResults(savedSession.SessionId);

--- a/Api.Client.Tests/SessionTests/ListTests.cs
+++ b/Api.Client.Tests/SessionTests/ListTests.cs
@@ -8,7 +8,7 @@ namespace Api.Client.Tests.SessionTests
 {
     public class ListTests : NexosisClient_TestsBase
     {
-        public ListTests() : 
+        public ListTests() :
             base(new
             {
                 items = new List<SessionResponse>
@@ -25,7 +25,7 @@ namespace Api.Client.Tests.SessionTests
             var result = await target.Sessions.List("alpha", "zulu", DateTimeOffset.Parse("2017-01-01 0:00 -0:00"), DateTimeOffset.Parse("2017-01-11 0:00 -0:00"));
 
             Assert.NotNull(result);
-            Assert.Equal(new Uri(baseUri, "sessions?dataSetName=alpha&eventName=zulu&requestedAfterDate=2017-01-01T00:00:00.0000000%2B00:00&requestedBeforeDate=2017-01-11T00:00:00.0000000%2B00:00"), handler.Request.RequestUri);
+            Assert.Equal(new Uri(baseUri, "sessions?page=0&pageSize=50dataSetName=alpha&eventName=zulu&requestedAfterDate=2017-01-01T00:00:00.0000000%2B00:00&requestedBeforeDate=2017-01-11T00:00:00.0000000%2B00:00"), handler.Request.RequestUri);
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace Api.Client.Tests.SessionTests
             var result = await target.Sessions.List();
 
             Assert.NotNull(result);
-            Assert.Equal(handler.Request.RequestUri, new Uri(baseUri, "sessions"));
+            Assert.Equal(handler.Request.RequestUri, new Uri(baseUri, "sessions?page=0&pageSize=50"));
         }
 
         [Fact]

--- a/Api.Client.Tests/SessionTests/ListTests.cs
+++ b/Api.Client.Tests/SessionTests/ListTests.cs
@@ -25,7 +25,7 @@ namespace Api.Client.Tests.SessionTests
             var result = await target.Sessions.List("alpha", "zulu", DateTimeOffset.Parse("2017-01-01 0:00 -0:00"), DateTimeOffset.Parse("2017-01-11 0:00 -0:00"));
 
             Assert.NotNull(result);
-            Assert.Equal(new Uri(baseUri, "sessions?page=0&pageSize=50dataSetName=alpha&eventName=zulu&requestedAfterDate=2017-01-01T00:00:00.0000000%2B00:00&requestedBeforeDate=2017-01-11T00:00:00.0000000%2B00:00"), handler.Request.RequestUri);
+            Assert.Equal(new Uri(baseUri, "sessions?page=0&pageSize=50&dataSetName=alpha&eventName=zulu&requestedAfterDate=2017-01-01T00:00:00.0000000%2B00:00&requestedBeforeDate=2017-01-11T00:00:00.0000000%2B00:00"), handler.Request.RequestUri);
         }
 
         [Fact]

--- a/Api.Client.Tests/ViewIntegrationTests.cs
+++ b/Api.Client.Tests/ViewIntegrationTests.cs
@@ -21,8 +21,6 @@ namespace Api.Client.Tests
             var data = DataSetGenerator.Run(DateTime.Parse("2017-01-01"), DateTime.Parse("2017-03-31"), "xray");
 
             var result = fixture.Client.DataSets.Create("mike", data).Result;
-
-
         }
 
         [Fact]
@@ -74,6 +72,17 @@ namespace Api.Client.Tests
             Assert.Equal(HttpStatusCode.NotFound, exception.StatusCode);
         }
 
+        [Fact]
+        public async Task ListContainsPagingData()
+        {
+            var view = new ViewInfo()
+            {
+                DataSetName = "mike"
+            };
+            var actual = await fixture.Client.Views.List(new ViewQuery { Page = 1, PageSize = 1 }) as IPagedList<ViewDefinition>;
+            Assert.NotNull(actual);
+            Assert.Equal(1, actual.PageSize);
+        }
 
 
 

--- a/Api.Client.Tests/ViewIntegrationTests.cs
+++ b/Api.Client.Tests/ViewIntegrationTests.cs
@@ -26,32 +26,41 @@ namespace Api.Client.Tests
         [Fact]
         public async Task CanSaveView()
         {
+            //This test fails occassionally because dataset doesn't exist
+            //adding within test to ensure success
+            var data = DataSetGenerator.Run(DateTime.Parse("2017-01-01"), DateTime.Parse("2017-03-31"), "xray");
+            await fixture.Client.DataSets.Create("forSaveView", data);
             var view = new ViewInfo()
             {
-                DataSetName = "mike"
+                DataSetName = "forSaveView"
             };
 
-            var result = await fixture.Client.Views.Create("mikeView", view);
+            var result = await fixture.Client.Views.Create("saveTestView", view);
 
-            Assert.Equal("mike", result.DataSetName);
-            Assert.Equal("mikeView", result.ViewName);
+            Assert.Equal("forSaveView", result.DataSetName);
+            Assert.Equal("saveTestView", result.ViewName);
+            await fixture.Client.DataSets.Remove("forSaveView", DataSetDeleteOptions.CascadeAll);
         }
 
 
         [Fact]
         public async Task ListViews()
         {
-
+            //This test fails occassionally because dataset doesn't exist
+            //adding within test to ensure success
+            var data = DataSetGenerator.Run(DateTime.Parse("2017-01-01"), DateTime.Parse("2017-03-31"), "xray");
+            await fixture.Client.DataSets.Create("forViewList", data);
             var view = new ViewInfo()
             {
-                DataSetName = "mike"
+                DataSetName = "forViewList"
             };
 
-            var result = await fixture.Client.Views.Create("mikeView", view);
+            var result = await fixture.Client.Views.Create("listTestView", view);
 
             var list = await fixture.Client.Views.List();
 
             Assert.True(list.Count > 0);
+            await fixture.Client.DataSets.Remove("forViewList", DataSetDeleteOptions.CascadeAll);
         }
 
         [Fact]

--- a/Api.Client.Tests/ViewTests/ListTests.cs
+++ b/Api.Client.Tests/ViewTests/ListTests.cs
@@ -47,5 +47,13 @@ namespace Api.Client.Tests.ViewTests
             Assert.Equal(HttpMethod.Get, handler.Request.Method);
             Assert.Equal(new Uri(baseUri, "views?Page=1&PageSize=10"), handler.Request.RequestUri);
         }
+
+        [Fact]
+        public async Task ResultIncludesPagingDetails()
+        {
+            var result = await target.Views.List(new ViewQuery { Page = 1, PageSize = 1 });
+            var actual = result as IPagedList<ViewDefinition>;
+            Assert.NotNull(actual);
+        }
     }
 }

--- a/Api.Client/DataSetClient.cs
+++ b/Api.Client/DataSetClient.cs
@@ -56,34 +56,43 @@ namespace Nexosis.Api.Client
             return await apiConnection.Put<DataSetSummary>($"data/{dataSetName}", null, input, httpMessageTransformer, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task<List<DataSetSummary>> List()
+        public Task<List<DataSetSummary>> List(int pageNumber = 0, int pageSize =50)
         {
-            return List(null);
+            return List(null, pageNumber, pageSize);
         }
 
-        public Task<List<DataSetSummary>> List(string partialName)
+        public Task<List<DataSetSummary>> List(string partialName, int pageNumber = 0, int pageSize = 50)
         {
-            return List(partialName, null);
+            return List(partialName, null, pageNumber, pageSize);
         }
 
-        public Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer)
+        public Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = 50)
         {
-            return List(partialName, httpMessageTransformer, CancellationToken.None);
+            return List(partialName, httpMessageTransformer, CancellationToken.None, pageNumber, pageSize);
         }
 
-        private class DataSetListResponse
+        private class DataSetListResponse : IPagedList<DataSetSummary>
         {
-            public List<DataSetSummary> items { get; set; }
+            [Newtonsoft.Json.JsonProperty("items")]
+            public List<DataSetSummary> Items { get; set; }
+            public int PageSize { get; set; }
+            public int PageNumber { get; set; }
+            public int TotalPages { get; set; }
+            public int TotalCount { get; set; }
+            public List<Link> Links { get; set; }
         }
-        public async Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken)
+
+        public async Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken, int pageNumber = 0, int pageSize = 50)
         {
-            Dictionary<string, string> parameters = null;
+            var parameters = new Dictionary<string, string>();
             if (!string.IsNullOrEmpty(partialName))
             {
-                parameters = new Dictionary<string, string> { { "partialName", partialName } };
+                parameters.Add("partialName", partialName);
             }
+            parameters.Add("page", pageNumber.ToString());
+            parameters.Add("pageSize", pageSize.ToString());
             var result = await apiConnection.Get<DataSetListResponse>("data", parameters, httpMessageTransformer, cancellationToken).ConfigureAwait(false);
-            return result?.items;
+            return new PagedList<DataSetSummary>(result);
         }
 
         public Task<DataSetData> Get(string dataSetName)

--- a/Api.Client/DataSetClient.cs
+++ b/Api.Client/DataSetClient.cs
@@ -61,12 +61,12 @@ namespace Nexosis.Api.Client
             return List(null, pageNumber, pageSize);
         }
 
-        public Task<List<DataSetSummary>> List(string partialName, int pageNumber = 0, int pageSize = 50)
+        public Task<List<DataSetSummary>> List(string partialName, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return List(partialName, null, pageNumber, pageSize);
         }
 
-        public Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = 50)
+        public Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return List(partialName, httpMessageTransformer, CancellationToken.None, pageNumber, pageSize);
         }
@@ -82,7 +82,7 @@ namespace Nexosis.Api.Client
             public List<Link> Links { get; set; }
         }
 
-        public async Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken, int pageNumber = 0, int pageSize = 50)
+        public async Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             var parameters = new Dictionary<string, string>();
             if (!string.IsNullOrEmpty(partialName))

--- a/Api.Client/IDataSetClient.cs
+++ b/Api.Client/IDataSetClient.cs
@@ -81,29 +81,35 @@ namespace Nexosis.Api.Client
         /// <summary>
         /// Gets the list of all datasets that have been saved to the system.
         /// </summary>
+        /// <param name="pageNumber">The page of the list results requested</param>
+        /// <param name="pageSize">How many items per page to return</param>
         /// <returns>A list of <see cref="DataSetSummary"/>.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/data</remarks>
-        Task<List<DataSetSummary>> List();
+        Task<List<DataSetSummary>> List(int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// Gets the list of datasets that have been saved to the system, filtering by partial name match.
         /// </summary>
         /// <param name="partialName">Limits results to only those datasets with names containing the specified value</param>
+        /// <param name="pageNumber">The page of the list results requested</param>
+        /// <param name="pageSize">How many items per page to return</param>
         /// <returns>A list of <see cref="DataSetSummary"/>.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/data</remarks>
-        Task<List<DataSetSummary>> List(string partialName);
+        Task<List<DataSetSummary>> List(string partialName, int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// Gets the list of datasets that have been saved to the system, filtering by partial name match.
         /// </summary>
         /// <param name="partialName">Limits results to only those datasets with names containing the specified value</param>
         /// <param name="httpMessageTransformer">A function that is called immediately before sending the request and after receiving a response which allows for message transformation.</param>
+        /// <param name="pageNumber">The page of the list results requested</param>
+        /// <param name="pageSize">How many items per page to return</param>
         /// <returns>A list of <see cref="DataSetSummary"/>.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/data</remarks>
-        Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer);
+        Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// Gets the list of datasets that have been saved to the system, filtering by partial name match.
@@ -111,10 +117,12 @@ namespace Nexosis.Api.Client
         /// <param name="partialName">Limits results to only those datasets with names containing the specified value</param>
         /// <param name="httpMessageTransformer">A function that is called immediately before sending the request and after receiving a response which allows for message transformation.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="pageNumber">The page of the list results requested</param>
+        /// <param name="pageSize">How many items per page to return</param>
         /// <returns>A list of <see cref="DataSetSummary"/>.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/data</remarks>
-        Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken);
+        Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken, int pageNumber = 0, int pageSize = 50);
 
         /// <summary>Get the data in the set.</summary>
         /// <param name="dataSetName">Name of the dataset for which to retrieve data.</param>

--- a/Api.Client/IDataSetClient.cs
+++ b/Api.Client/IDataSetClient.cs
@@ -86,7 +86,7 @@ namespace Nexosis.Api.Client
         /// <returns>A list of <see cref="DataSetSummary"/>.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/data</remarks>
-        Task<List<DataSetSummary>> List(int pageNumber = 0, int pageSize = 50);
+        Task<List<DataSetSummary>> List(int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// Gets the list of datasets that have been saved to the system, filtering by partial name match.
@@ -97,7 +97,7 @@ namespace Nexosis.Api.Client
         /// <returns>A list of <see cref="DataSetSummary"/>.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/data</remarks>
-        Task<List<DataSetSummary>> List(string partialName, int pageNumber = 0, int pageSize = 50);
+        Task<List<DataSetSummary>> List(string partialName, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// Gets the list of datasets that have been saved to the system, filtering by partial name match.
@@ -109,7 +109,7 @@ namespace Nexosis.Api.Client
         /// <returns>A list of <see cref="DataSetSummary"/>.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/data</remarks>
-        Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = 50);
+        Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// Gets the list of datasets that have been saved to the system, filtering by partial name match.
@@ -122,7 +122,7 @@ namespace Nexosis.Api.Client
         /// <returns>A list of <see cref="DataSetSummary"/>.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/data</remarks>
-        Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken, int pageNumber = 0, int pageSize = 50);
+        Task<List<DataSetSummary>> List(string partialName, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>Get the data in the set.</summary>
         /// <param name="dataSetName">Name of the dataset for which to retrieve data.</param>

--- a/Api.Client/IImportClient.cs
+++ b/Api.Client/IImportClient.cs
@@ -12,19 +12,23 @@ namespace Nexosis.Api.Client
         /// <summary>
         /// List imports that have been run. This will show information about them such as id and status
         /// </summary>
+        /// <param name="pageNumber">The page of the list results requested</param>
+        /// <param name="pageSize">How many items per page to return</param>
         /// <returns>The list of <see cref="ImportDetail"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/imports</remarks>
-        Task<List<ImportDetail>> List();
+        Task<List<ImportDetail>> List(int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// List imports that have been run. This will show information about them such as id and status
         /// </summary>
         /// <param name="dataSetName">Limits imports to those with the specified name.</param>
+        /// <param name="pageNumber">The page of the list results requested</param>
+        /// <param name="pageSize">How many items per page to return</param>
         /// <returns>The list of <see cref="ImportDetail"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/imports</remarks>
-        Task<List<ImportDetail>> List(string dataSetName);
+        Task<List<ImportDetail>> List(string dataSetName, int pageNumber = 0, int pageSize = 50);
 
 
         /// <summary>
@@ -33,11 +37,13 @@ namespace Nexosis.Api.Client
         /// <param name="dataSetName">Limits imports to those with the specified name.</param>
         /// <param name="requestedAfterDate">Limits imports to those requested on or after the specified date.</param>
         /// <param name="requestedBeforeDate">Limits imports to those requested on or before the specified date.</param>
+        /// <param name="pageNumber">The page of the list results requested</param>
+        /// <param name="pageSize">How many items per page to return</param>
         /// <returns>The list of <see cref="ImportDetail"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/imports</remarks>
         Task<List<ImportDetail>> List(string dataSetName, DateTimeOffset requestedAfterDate,
-            DateTimeOffset requestedBeforeDate);
+            DateTimeOffset requestedBeforeDate, int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// List imports that have been run. This will show information about them such as id and status
@@ -46,11 +52,13 @@ namespace Nexosis.Api.Client
         /// <param name="requestedAfterDate">Limits imports to those requested on or after the specified date.</param>
         /// <param name="requestedBeforeDate">Limits imports to those requested on or before the specified date.</param>
         /// <param name="httpMessageTransformer">A function that is called immediately before sending the request and after receiving a response which allows for message transformation.</param>
+        /// <param name="pageNumber">The page of the list results requested</param>
+        /// <param name="pageSize">How many items per page to return</param>
         /// <returns>The list of <see cref="ImportDetail"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/imports</remarks>
         Task<List<ImportDetail>> List(string dataSetName, DateTimeOffset requestedAfterDate,
-            DateTimeOffset requestedBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer);
+            DateTimeOffset requestedBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// List imports that have been run. This will show information about them such as id and status
@@ -60,12 +68,14 @@ namespace Nexosis.Api.Client
         /// <param name="requestedBeforeDate">Limits imports to those requested on or before the specified date.</param>
         /// <param name="httpMessageTransformer">A function that is called immediately before sending the request and after receiving a response which allows for message transformation.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="pageNumber">The page of the list results requested</param>
+        /// <param name="pageSize">How many items per page to return</param>
         /// <returns>The list of <see cref="ImportDetail"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/imports</remarks>
         Task<List<ImportDetail>> List(string dataSetName, DateTimeOffset requestedAfterDate,
             DateTimeOffset requestedBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer,
-            CancellationToken cancellationToken);
+            CancellationToken cancellationToken, int pageNumber = 0, int pageSize = 50);
 
 
         /// <summary>

--- a/Api.Client/IImportClient.cs
+++ b/Api.Client/IImportClient.cs
@@ -17,7 +17,7 @@ namespace Nexosis.Api.Client
         /// <returns>The list of <see cref="ImportDetail"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/imports</remarks>
-        Task<List<ImportDetail>> List(int pageNumber = 0, int pageSize = 50);
+        Task<List<ImportDetail>> List(int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// List imports that have been run. This will show information about them such as id and status
@@ -28,7 +28,7 @@ namespace Nexosis.Api.Client
         /// <returns>The list of <see cref="ImportDetail"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/imports</remarks>
-        Task<List<ImportDetail>> List(string dataSetName, int pageNumber = 0, int pageSize = 50);
+        Task<List<ImportDetail>> List(string dataSetName, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Nexosis.Api.Client
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/imports</remarks>
         Task<List<ImportDetail>> List(string dataSetName, DateTimeOffset requestedAfterDate,
-            DateTimeOffset requestedBeforeDate, int pageNumber = 0, int pageSize = 50);
+            DateTimeOffset requestedBeforeDate, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// List imports that have been run. This will show information about them such as id and status
@@ -58,7 +58,7 @@ namespace Nexosis.Api.Client
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/imports</remarks>
         Task<List<ImportDetail>> List(string dataSetName, DateTimeOffset requestedAfterDate,
-            DateTimeOffset requestedBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = 50);
+            DateTimeOffset requestedBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// List imports that have been run. This will show information about them such as id and status
@@ -75,7 +75,7 @@ namespace Nexosis.Api.Client
         /// <remarks>GET of https://ml.nexosis.com/api/imports</remarks>
         Task<List<ImportDetail>> List(string dataSetName, DateTimeOffset requestedAfterDate,
             DateTimeOffset requestedBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer,
-            CancellationToken cancellationToken, int pageNumber = 0, int pageSize = 50);
+            CancellationToken cancellationToken, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
 
         /// <summary>

--- a/Api.Client/IModelClient.cs
+++ b/Api.Client/IModelClient.cs
@@ -21,40 +21,23 @@ namespace Nexosis.Api.Client
         /// <summary>
         /// Gets the list of all models that have been created.
         /// </summary>
-        /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
-        /// <returns>A list of <see cref="ModelSummary"/>.</returns>
-        /// <remarks>GET of https://ml.nexosis.com/api/model</remarks>
-        Task<List<ModelSummary>>List();
-
-        /// <summary>
-        /// Gets the list of all models that have been created.
-        /// </summary>
-        /// <param name="page">zero index page of the results to get</param>
+        /// <param name="pageNumber">zero index page of the results to get</param>
         /// <param name="pageSize">number of items per page</param>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <returns>A list of <see cref="ModelSummary"/>.</returns>
         /// <remarks>GET of https://ml.nexosis.com/api/model</remarks>
-        Task<List<ModelSummary>>List(int page, int pageSize);
+        Task<List<ModelSummary>>List(int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// Gets the list of all models that have been created.
         /// </summary>
         /// <param name="dataSourceName">Limits models to those for a particular data source.</param>
-        /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
-        /// <returns>A list of <see cref="ModelSummary"/>.</returns>
-        /// <remarks>GET of https://ml.nexosis.com/api/model</remarks>
-        Task<List<ModelSummary>>List(string dataSourceName);
-
-        /// <summary>
-        /// Gets the list of all models that have been created.
-        /// </summary>
-        /// <param name="dataSourceName">Limits models to those for a particular data source.</param>
-        /// <param name="page">zero index page of the results to get</param>
+        /// <param name="pageNumber">zero index page of the results to get</param>
         /// <param name="pageSize">number of items per page</param>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <returns>A list of <see cref="ModelSummary"/>.</returns>
         /// <remarks>GET of https://ml.nexosis.com/api/model</remarks>
-        Task<List<ModelSummary>>List(string dataSourceName, int page, int pageSize);
+        Task<List<ModelSummary>>List(string dataSourceName, int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// Gets the list of all models that have been created.
@@ -62,10 +45,12 @@ namespace Nexosis.Api.Client
         /// <param name="dataSourceName">Limits models to those for a particular data source.</param>
         /// <param name="createdAfterDate">Limits sessions to those requested on or after the specified date.</param>
         /// <param name="createdBeforeDate">Limits sessions to those requested on or before the specified date.</param>
+        /// <param name="pageNumber">zero index page of the results to get</param>
+        /// <param name="pageSize">number of items per page</param>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <returns>A list of <see cref="ModelSummary"/>.</returns>
         /// <remarks>GET of https://ml.nexosis.com/api/model</remarks>
-        Task<List<ModelSummary>>List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate);
+        Task<List<ModelSummary>>List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// Gets the list of all models that have been created.
@@ -74,10 +59,12 @@ namespace Nexosis.Api.Client
         /// <param name="createdAfterDate">Limits sessions to those requested on or after the specified date.</param>
         /// <param name="createdBeforeDate">Limits sessions to those requested on or before the specified date.</param>
         /// <param name="httpMessageTransformer">A function that is called immediately before sending the request and after receiving a response which allows for message transformation.</param>
+        /// <param name="pageNumber">zero index page of the results to get</param>
+        /// <param name="pageSize">number of items per page</param>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <returns>A list of <see cref="ModelSummary"/>.</returns>
         /// <remarks>GET of https://ml.nexosis.com/api/model</remarks>
-        Task<List<ModelSummary>>List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer);
+        Task<List<ModelSummary>>List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// Gets the list of all models that have been created.
@@ -87,10 +74,12 @@ namespace Nexosis.Api.Client
         /// <param name="createdBeforeDate">Limits sessions to those requested on or before the specified date.</param>
         /// <param name="httpMessageTransformer">A function that is called immediately before sending the request and after receiving a response which allows for message transformation.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="pageNumber">zero index page of the results to get</param>
+        /// <param name="pageSize">number of items per page</param>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <returns>A list of <see cref="ModelSummary"/>.</returns>
         /// <remarks>GET of https://ml.nexosis.com/api/model</remarks>
-        Task<List<ModelSummary>>List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken);
+        Task<List<ModelSummary>>List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken, int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// Predicts target values for a set of features using the specified model. 

--- a/Api.Client/IModelClient.cs
+++ b/Api.Client/IModelClient.cs
@@ -26,7 +26,7 @@ namespace Nexosis.Api.Client
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <returns>A list of <see cref="ModelSummary"/>.</returns>
         /// <remarks>GET of https://ml.nexosis.com/api/model</remarks>
-        Task<List<ModelSummary>>List(int pageNumber = 0, int pageSize = 50);
+        Task<List<ModelSummary>>List(int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// Gets the list of all models that have been created.
@@ -37,7 +37,7 @@ namespace Nexosis.Api.Client
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <returns>A list of <see cref="ModelSummary"/>.</returns>
         /// <remarks>GET of https://ml.nexosis.com/api/model</remarks>
-        Task<List<ModelSummary>>List(string dataSourceName, int pageNumber = 0, int pageSize = 50);
+        Task<List<ModelSummary>>List(string dataSourceName, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// Gets the list of all models that have been created.
@@ -50,7 +50,7 @@ namespace Nexosis.Api.Client
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <returns>A list of <see cref="ModelSummary"/>.</returns>
         /// <remarks>GET of https://ml.nexosis.com/api/model</remarks>
-        Task<List<ModelSummary>>List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, int pageNumber = 0, int pageSize = 50);
+        Task<List<ModelSummary>>List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// Gets the list of all models that have been created.
@@ -64,7 +64,7 @@ namespace Nexosis.Api.Client
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <returns>A list of <see cref="ModelSummary"/>.</returns>
         /// <remarks>GET of https://ml.nexosis.com/api/model</remarks>
-        Task<List<ModelSummary>>List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = 50);
+        Task<List<ModelSummary>>List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// Gets the list of all models that have been created.
@@ -79,7 +79,7 @@ namespace Nexosis.Api.Client
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <returns>A list of <see cref="ModelSummary"/>.</returns>
         /// <remarks>GET of https://ml.nexosis.com/api/model</remarks>
-        Task<List<ModelSummary>>List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken, int pageNumber = 0, int pageSize = 50);
+        Task<List<ModelSummary>>List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// Predicts target values for a set of features using the specified model. 

--- a/Api.Client/ISessionClient.cs
+++ b/Api.Client/ISessionClient.cs
@@ -575,47 +575,30 @@ namespace Nexosis.Api.Client
         /// <returns>The list of <see cref="SessionResponse"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/sessions</remarks>
-        Task<List<SessionResponse>> List();
-
-        /// <summary>
-        /// List sessions that have been run. This will show the information about them such as the id, status, and the analysis date range. 
-        /// </summary>
-        /// <param name="page">zero index page of the results to get</param>
-        /// <param name="pageSize">number of items per page</param>
-        /// <returns>The list of <see cref="SessionResponse"/> objects.</returns>
-        /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
-        /// <remarks>GET of https://ml.nexosis.com/api/sessions</remarks>
-        Task<List<SessionResponse>> List(int page, int pageSize);
+        Task<List<SessionResponse>> List(int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// List sessions that have been run. This will show the information about them such as the id, status, and the analysis date range. 
         /// </summary>
         /// <param name="dataSetName">Limits sessions to those with the specified name.</param>
-        /// <returns>The list of <see cref="SessionResponse"/> objects.</returns>
-        /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
-        /// <remarks>GET of https://ml.nexosis.com/api/sessions</remarks>
-        Task<List<SessionResponse>> List(string dataSetName);
-
-        /// <summary>
-        /// List sessions that have been run. This will show the information about them such as the id, status, and the analysis date range. 
-        /// </summary>
-        /// <param name="dataSetName">Limits sessions to those with the specified name.</param>
-        /// <param name="page">zero index page of the results to get</param>
+        /// <param name="pageNumber">zero index page of the results to get</param>
         /// <param name="pageSize">number of items per page</param>
         /// <returns>The list of <see cref="SessionResponse"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/sessions</remarks>
-        Task<List<SessionResponse>> List(string dataSetName, int page, int pageSize);
+        Task<List<SessionResponse>> List(string dataSetName, int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// List sessions that have been run. This will show the information about them such as the id, status, and the analysis date range. 
         /// </summary>
         /// <param name="dataSetName">Limits sessions to those with the specified name.</param>
         /// <param name="eventName">Limits impact sessions to those for a particular event.</param>
+        /// <param name="pageNumber">zero index page of the results to get</param>
+        /// <param name="pageSize">number of items per page</param>
         /// <returns>The list of <see cref="SessionResponse"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/sessions</remarks>
-        Task<List<SessionResponse>> List(string dataSetName, string eventName);
+        Task<List<SessionResponse>> List(string dataSetName, string eventName, int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// List sessions that have been run. This will show the information about them such as the id, status, and the analysis date range. 
@@ -624,10 +607,12 @@ namespace Nexosis.Api.Client
         /// <param name="eventName">Limits impact sessions to those for a particular event.</param>
         /// <param name="requestedAfterDate">Limits sessions to those requested on or after the specified date.</param>
         /// <param name="requestedBeforeDate">Limits sessions to those requested on or before the specified date.</param>
+        /// <param name="pageNumber">zero index page of the results to get</param>
+        /// <param name="pageSize">number of items per page</param>
         /// <returns>The list of <see cref="SessionResponse"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/sessions</remarks>
-        Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate);
+        Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate, int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// List sessions that have been run. This will show the information about them such as the id, status, and the analysis date range. 
@@ -637,10 +622,12 @@ namespace Nexosis.Api.Client
         /// <param name="requestedAfterDate">Limits sessions to those requested on or after the specified date.</param>
         /// <param name="requestedBeforeDate">Limits sessions to those requested on or before the specified date.</param>
         /// <param name="httpMessageTransformer">A function that is called immediately before sending the request and after receiving a response which allows for message transformation.</param>
+        /// <param name="pageNumber">zero index page of the results to get</param>
+        /// <param name="pageSize">number of items per page</param>
         /// <returns>The list of <see cref="SessionResponse"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/sessions</remarks>
-        Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer);
+        Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// List sessions that have been run. This will show the information about them such as the id, status, and the analysis date range. 
@@ -651,10 +638,12 @@ namespace Nexosis.Api.Client
         /// <param name="requestedBeforeDate">Limits sessions to those requested on or before the specified date.</param>
         /// <param name="httpMessageTransformer">A function that is called immediately before sending the request and after receiving a response which allows for message transformation.</param>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="pageNumber">zero index page of the results to get</param>
+        /// <param name="pageSize">number of items per page</param>
         /// <returns>The list of <see cref="SessionResponse"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/sessions</remarks>
-        Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken);
+        Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken, int pageNumber = 0, int pageSize = 50);
 
         /// <summary>
         /// Remove sessions that have been run.

--- a/Api.Client/ISessionClient.cs
+++ b/Api.Client/ISessionClient.cs
@@ -575,7 +575,7 @@ namespace Nexosis.Api.Client
         /// <returns>The list of <see cref="SessionResponse"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/sessions</remarks>
-        Task<List<SessionResponse>> List(int pageNumber = 0, int pageSize = 50);
+        Task<List<SessionResponse>> List(int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// List sessions that have been run. This will show the information about them such as the id, status, and the analysis date range. 
@@ -586,7 +586,7 @@ namespace Nexosis.Api.Client
         /// <returns>The list of <see cref="SessionResponse"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/sessions</remarks>
-        Task<List<SessionResponse>> List(string dataSetName, int pageNumber = 0, int pageSize = 50);
+        Task<List<SessionResponse>> List(string dataSetName, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// List sessions that have been run. This will show the information about them such as the id, status, and the analysis date range. 
@@ -598,7 +598,7 @@ namespace Nexosis.Api.Client
         /// <returns>The list of <see cref="SessionResponse"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/sessions</remarks>
-        Task<List<SessionResponse>> List(string dataSetName, string eventName, int pageNumber = 0, int pageSize = 50);
+        Task<List<SessionResponse>> List(string dataSetName, string eventName, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// List sessions that have been run. This will show the information about them such as the id, status, and the analysis date range. 
@@ -612,7 +612,7 @@ namespace Nexosis.Api.Client
         /// <returns>The list of <see cref="SessionResponse"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/sessions</remarks>
-        Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate, int pageNumber = 0, int pageSize = 50);
+        Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// List sessions that have been run. This will show the information about them such as the id, status, and the analysis date range. 
@@ -627,7 +627,7 @@ namespace Nexosis.Api.Client
         /// <returns>The list of <see cref="SessionResponse"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/sessions</remarks>
-        Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = 50);
+        Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// List sessions that have been run. This will show the information about them such as the id, status, and the analysis date range. 
@@ -643,7 +643,7 @@ namespace Nexosis.Api.Client
         /// <returns>The list of <see cref="SessionResponse"/> objects.</returns>
         /// <exception cref="NexosisClientException">Thrown when 4xx or 5xx response is received from server, or errors in parsing the response.</exception>
         /// <remarks>GET of https://ml.nexosis.com/api/sessions</remarks>
-        Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken, int pageNumber = 0, int pageSize = 50);
+        Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize);
 
         /// <summary>
         /// Remove sessions that have been run.

--- a/Api.Client/ImportClient.cs
+++ b/Api.Client/ImportClient.cs
@@ -39,18 +39,18 @@ namespace Nexosis.Api.Client
             public Dictionary<string, ColumnMetadata> Columns { get; set; }
         }
 
-        public async Task<List<ImportDetail>> List(int pageNumber = 0, int pageSize = 50)
+        public async Task<List<ImportDetail>> List(int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return await ListInternal(pageNumber: pageNumber, pageSize: pageSize).ConfigureAwait(false);
         }
 
-        public async Task<List<ImportDetail>> List(string dataSetName, int pageNumber = 0, int pageSize = 50)
+        public async Task<List<ImportDetail>> List(string dataSetName, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return await ListInternal(dataSetName: dataSetName, pageNumber: pageNumber, pageSize: pageSize).ConfigureAwait(false);
         }
 
         public async Task<List<ImportDetail>> List(string dataSetName, DateTimeOffset requestedAfterDate,
-            DateTimeOffset requestedBeforeDate, int pageNumber = 0, int pageSize = 50)
+            DateTimeOffset requestedBeforeDate, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return await ListInternal(dataSetName: dataSetName,
                 requestedAfterDate: requestedAfterDate,
@@ -60,7 +60,7 @@ namespace Nexosis.Api.Client
 
         public async Task<List<ImportDetail>> List(string dataSetName, DateTimeOffset requestedAfterDate,
             DateTimeOffset requestedBeforeDate,
-            Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = 50)
+            Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return await ListInternal(dataSetName: dataSetName,
                 requestedAfterDate: requestedAfterDate,
@@ -73,7 +73,7 @@ namespace Nexosis.Api.Client
         public async Task<List<ImportDetail>> List(string dataSetName, DateTimeOffset requestedAfterDate,
             DateTimeOffset requestedBeforeDate,
             Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken
-            , int pageNumber = 0, int pageSize = 50)
+            , int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return await ListInternal(dataSetName: dataSetName,
                 requestedAfterDate: requestedAfterDate,
@@ -87,7 +87,7 @@ namespace Nexosis.Api.Client
            DateTimeOffset? requestedAfterDate = null,
            DateTimeOffset? requestedBeforeDate = null,
            int pageNumber = 0,
-           int pageSize = 50,
+           int pageSize = NexosisClient.DefaultPageSize,
            Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer = null,
            CancellationToken? cancellationToken = null)
         {

--- a/Api.Client/Model/PagedList.cs
+++ b/Api.Client/Model/PagedList.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nexosis.Api.Client.Model
+{
+    /// <summary>
+    /// Utility class to wrap list responses from GET entity requests
+    /// </summary>
+    /// <typeparam name="T">The type of listed entity to wrap</typeparam>
+    public class PagedList<T> : List<T>, IPagedList<T>
+    {
+        /// <summary>
+        /// Initialize the object with an existing collection
+        /// </summary>
+        /// <param name="collection"></param>
+        public PagedList(IEnumerable<T> collection) : base(collection)
+        {
+        }
+
+        /// <summary>
+        /// Initialize with a paged serialized response object 
+        /// </summary>
+        /// <param name="response">The response directly from the api client request</param>
+        public PagedList(IPagedList<T> response)
+        {
+            PageSize = response.PageSize;
+            PageNumber = response.PageNumber;
+            TotalPages = response.TotalPages;
+            TotalCount = response.TotalCount;
+            Links = response.Links;
+            if (response.Items != null)
+                this.InsertRange(0, response.Items);
+        }
+
+        public int PageSize { get; set; }
+        public int PageNumber { get; set; }
+        public int TotalPages { get; set; }
+        public int TotalCount { get; set; }
+        public List<Link> Links { get; set; }
+        public List<T> Items { get; set; }
+    }
+
+    public interface IPagedList<T>
+    {
+        int PageSize { get; set; }
+        int PageNumber { get; set; }
+        int TotalPages { get; set; }
+        int TotalCount { get; set; }
+        List<Link> Links { get; set; }
+        List<T> Items { get; set; }
+    }
+}

--- a/Api.Client/ModelClient.cs
+++ b/Api.Client/ModelClient.cs
@@ -27,7 +27,7 @@ namespace Nexosis.Api.Client
             return await apiConnection.Get<ModelSummary>($"models/{id}", null, httpMessageTransformer, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task<List<ModelSummary>> List(int pageNumber = 0, int pageSize = 50)
+        public Task<List<ModelSummary>> List(int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             var parameters = new Dictionary<string, string>
             {
@@ -37,7 +37,7 @@ namespace Nexosis.Api.Client
             return ListModelInternal(parameters, null, CancellationToken.None);
         }
 
-        public Task<List<ModelSummary>> List(string dataSourceName, int pageNumber = 0, int pageSize = 50)
+        public Task<List<ModelSummary>> List(string dataSourceName, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             var parameters = new Dictionary<string, string>
             {
@@ -49,17 +49,17 @@ namespace Nexosis.Api.Client
             return ListModelInternal(parameters, null, CancellationToken.None);
         }
 
-        public Task<List<ModelSummary>> List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, int pageNumber = 0, int pageSize = 50)
+        public Task<List<ModelSummary>> List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return List(dataSourceName, createdAfterDate, createdBeforeDate, null, CancellationToken.None, pageNumber, pageSize);
         }
 
-        public Task<List<ModelSummary>> List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = 50)
+        public Task<List<ModelSummary>> List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return List(dataSourceName, createdAfterDate, createdBeforeDate, httpMessageTransformer, CancellationToken.None, pageNumber, pageSize);
         }
 
-        public Task<List<ModelSummary>> List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken, int pageNumber = 0, int pageSize = 50)
+        public Task<List<ModelSummary>> List(string dataSourceName, DateTimeOffset createdAfterDate, DateTimeOffset createdBeforeDate, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             var parameters = new Dictionary<string, string>
             {

--- a/Api.Client/NexosisClient.cs
+++ b/Api.Client/NexosisClient.cs
@@ -43,6 +43,7 @@ namespace Nexosis.Api.Client
         public string ConfiguredUrl => configuredUrl ?? BaseUrl;
 
         public const int MaxPageSize = 1000;
+        public const int DefaultPageSize = 50;
 
         /// <summary>
         /// Constructs a instance of the client with the api key read from an environement variable

--- a/Api.Client/SessionClient.cs
+++ b/Api.Client/SessionClient.cs
@@ -386,36 +386,36 @@ namespace Nexosis.Api.Client
             return apiConnection.Post<SessionResponse>(path, null, data, httpMessageTransformer, cancellationToken);
         }
 
-        public Task<List<SessionResponse>> List(int pageNumber = 0, int pageSize = 50)
+        public Task<List<SessionResponse>> List(int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return ListSessionsInternal(BuildListParameters(null, pageNumber, pageSize), null, CancellationToken.None);
         }
 
-        public Task<List<SessionResponse>> List(string dataSetName, int pageNumber = 0, int pageSize = 50)
+        public Task<List<SessionResponse>> List(string dataSetName, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return ListSessionsInternal(BuildListParameters(dataSetName, pageNumber, pageSize), null, CancellationToken.None);
         }
 
-        public Task<List<SessionResponse>> List(string dataSetName, string eventName, int pageNumber = 0, int pageSize = 50)
+        public Task<List<SessionResponse>> List(string dataSetName, string eventName, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return ListSessionsInternal(BuildListParameters(dataSetName, pageNumber, pageSize, eventName), null, CancellationToken.None);
         }
 
-        public Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate, int pageNumber = 0, int pageSize = 50)
+        public Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate, int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return ListSessionsInternal(BuildListParameters(dataSetName, pageNumber, pageSize, eventName, requestedAfterDate, requestedBeforeDate), null, CancellationToken.None);
         }
 
         public Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate,
             Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer
-            , int pageNumber = 0, int pageSize = 50)
+            , int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return ListSessionsInternal(BuildListParameters(dataSetName, pageNumber, pageSize, eventName, requestedAfterDate, requestedBeforeDate), httpMessageTransformer, CancellationToken.None);
         }
 
         public Task<List<SessionResponse>> List(string dataSetName, string eventName, DateTimeOffset requestedAfterDate, DateTimeOffset requestedBeforeDate,
             Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken
-            , int pageNumber = 0, int pageSize = 50)
+            , int pageNumber = 0, int pageSize = NexosisClient.DefaultPageSize)
         {
             return ListSessionsInternal(BuildListParameters(dataSetName, pageNumber, pageSize, eventName, requestedAfterDate, requestedBeforeDate), httpMessageTransformer, cancellationToken);
         }

--- a/Api.Client/ViewClient.cs
+++ b/Api.Client/ViewClient.cs
@@ -27,9 +27,15 @@ namespace Nexosis.Api.Client
             return List(new ViewQuery(), httpMessageTransformer, cancellationToken);
         }
 
-        private class ViewListResponse
+        private class ViewListResponse : IPagedList<ViewDefinition>
         {
-            public List<ViewDefinition> items { get; set; }
+            [Newtonsoft.Json.JsonProperty("items")]
+            public List<ViewDefinition> Items { get; set; }
+            public int PageSize { get; set; }
+            public int PageNumber { get; set; }
+            public int TotalPages { get; set; }
+            public int TotalCount { get; set; }
+            public List<Link> Links { get; set; }
         }
 
         public async Task<List<ViewDefinition>> List(ViewQuery query, Action<HttpRequestMessage, HttpResponseMessage> httpMessageTransformer, CancellationToken cancellationToken)
@@ -51,8 +57,7 @@ namespace Nexosis.Api.Client
             {
                 parameters.Add(nameof(query.PageSize), query.PageSize.ToString());
             }
-
-            return (await apiConnection.Get<ViewListResponse>($"views", parameters, httpMessageTransformer, cancellationToken).ConfigureAwait(false))?.items;
+            return new PagedList<ViewDefinition>(await apiConnection.Get<ViewListResponse>($"views", parameters, httpMessageTransformer, cancellationToken).ConfigureAwait(false));
         }
 
         public Task<List<ViewDefinition>> List(ViewQuery query)


### PR DESCRIPTION
Added a wrapper for list results to include the paging information
Also updated each list operation to have default paging 
If not for non-breaking changes, there is a strong need for a parameters/query variable to hold both paging and other query params. Overloads on sessions and datasets are out of control.