### PR TITLE
Punt on strong typing of dataset column stats shape until further discussion

### DIFF
--- a/Api.Client.Tests/DataSetTests/StatsTests.cs
+++ b/Api.Client.Tests/DataSetTests/StatsTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using Nexosis.Api.Client.Model;
 using Xunit;
 
@@ -12,11 +13,12 @@ namespace Api.Client.Tests.DataSetTests
         public StatsTests() : base(new DataSourceStatsResult()
         {
             DataSetName = "test",
-            Columns = new Dictionary<string, Dictionary<string, double>>()
+            Columns = new Dictionary<string, JObject>()
             {
-                ["column1"] = new Dictionary<string, double>() {["count"] = 1}
+                ["column1"] = JObject.Parse("{ \"count\": 1 }")
             }
-        }) { }
+        })
+        { }
 
         [Fact]
         public async Task GetStatsByName()

--- a/Api.Client/Model/DataSourceStatsResult.cs
+++ b/Api.Client/Model/DataSourceStatsResult.cs
@@ -1,10 +1,17 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace Nexosis.Api.Client.Model
 {
     public class DataSourceStatsResult
     {
+        /// <summary>
+        /// Name of the dataset for which statistics were retrieved
+        /// </summary>
         public string DataSetName { get; set; }
-        public Dictionary<string, Dictionary<string, double>> Columns { get; set; }
+        /// <summary>
+        /// Statistics about each column in the dataset
+        /// </summary>
+        public Dictionary<string, JObject> Columns { get; set; }
     }
 }


### PR DESCRIPTION
With the most recent stats changes the client gets JSON deserialization errors. This fixes those errors and allows us time to discuss whether or not to expose a strongly typed stats object.