### PR TITLE
#20 - add .net objects directly

### DIFF
--- a/Api.Client.Tests/ModelsTests/DataSetDetailConstructorTests.cs
+++ b/Api.Client.Tests/ModelsTests/DataSetDetailConstructorTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Nexosis.Api.Client.Model;
+using Xunit;
+
+namespace Api.Client.Tests.ModelsTests
+{
+    public class DataSetDetailConstructorTests
+    {
+        #region classes used for testing
+        internal class TestObject
+        {
+            public string Foo { get; set; }
+            public int Bar { get; set; }
+        }
+
+        internal class ComplexTestObject
+        {
+            public TestObject Complex { get; set; }
+            public string Abc { get; set; }
+        }
+        #endregion
+
+        [Fact]
+        public void PopulatedByObjects()
+        {
+            // arrange
+            var testObject1 = new TestObject {Foo = Guid.NewGuid().ToString(), Bar = 123 };
+            var testObject2 = new TestObject {Foo = Guid.NewGuid().ToString(), Bar = 456 };
+            var list = new List<dynamic> {testObject1, testObject2};
+
+            // act
+            var dataSetDetail = new DataSetDetail(list);
+
+            // assert
+            Assert.True(dataSetDetail.Data.Any(d => d.ContainsKey("Foo")));
+            Assert.True(dataSetDetail.Data.SingleOrDefault(d => d.ContainsKey("Foo") && d.ContainsValue(testObject1.Foo)) != null);
+            Assert.True(dataSetDetail.Data.SingleOrDefault(d => d.ContainsKey("Bar") && d.ContainsValue(testObject1.Bar.ToString())) != null);
+            Assert.True(dataSetDetail.Data.SingleOrDefault(d => d.ContainsKey("Foo") && d.ContainsValue(testObject2.Foo)) != null);
+            Assert.True(dataSetDetail.Data.SingleOrDefault(d => d.ContainsKey("Bar") && d.ContainsValue(testObject2.Bar.ToString())) != null);
+        }
+
+        [Fact]
+        public void CantBePopulatedByComplexObjects()
+        {
+            // arrange
+            var testObject1 = new ComplexTestObject
+            {
+                Abc = Guid.NewGuid().ToString(),
+                Complex = new TestObject {Foo = Guid.NewGuid().ToString(), Bar = 789 }
+
+            };
+            var list = new List<dynamic> {testObject1 };
+
+            // act
+            void Act() { new DataSetDetail(list); }
+
+            // assert
+            Assert.Throws<JsonReaderException>((Action) Act);
+        }
+
+        [Fact]
+        public void PopulatedByAnonymousObjects()
+        {
+            // arrange
+            var testObject1 = new { Foo = Guid.NewGuid().ToString(), Bar = 777 };
+            var testObject2 = new { Foo = Guid.NewGuid().ToString(), Bar = 888 };
+            var list = new List<dynamic> { testObject1, testObject2 };
+
+            // act
+            var dataSetDetail = new DataSetDetail(list);
+
+            // assert
+            Assert.True(dataSetDetail.Data.Any(d => d.ContainsKey("Foo")));
+            Assert.True(dataSetDetail.Data.SingleOrDefault(d => d.ContainsKey("Foo") && d.ContainsValue(testObject1.Foo)) != null);
+            Assert.True(dataSetDetail.Data.SingleOrDefault(d => d.ContainsKey("Bar") && d.ContainsValue(testObject1.Bar.ToString())) != null);
+            Assert.True(dataSetDetail.Data.SingleOrDefault(d => d.ContainsKey("Foo") && d.ContainsValue(testObject2.Foo)) != null);
+            Assert.True(dataSetDetail.Data.SingleOrDefault(d => d.ContainsKey("Bar") && d.ContainsValue(testObject2.Bar.ToString())) != null);
+        }
+    }
+}

--- a/Api.Client/Model/DataSetDetail.cs
+++ b/Api.Client/Model/DataSetDetail.cs
@@ -1,10 +1,23 @@
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace Nexosis.Api.Client.Model
 {
     public class DataSetDetail
     {
+        public DataSetDetail() { }
+
+        /// <summary>
+        /// Create a DataSetDetail using a collection of .NET object
+        /// </summary>
+        /// <param name="obj">The objects must be simple objects that can be deserialized into a simple string dictionary</param>
+        public DataSetDetail(List<dynamic> obj)
+        {
+            var json = JsonConvert.SerializeObject(obj);
+            Data = JsonConvert.DeserializeObject<List<Dictionary<string, string>>>(json);
+        }
+
         /// <summary>The data</summary>
         /// <remarks>The dictionaries added to the list should treat the keys case insensitive. The API ignores case on column names.</remarks>
         public List<Dictionary<string, string>> Data { get; set; } = new List<Dictionary<string, string>>();
@@ -12,6 +25,5 @@ namespace Nexosis.Api.Client.Model
         /// <summary>Metadata about each column in the dataset</summary>
         /// <remarks>This is initialized as a case-insensitive dictionary. The API ignores case for column names.</remarks>
         public Dictionary<string, ColumnMetadata> Columns { get; set; } = new Dictionary<string, ColumnMetadata>(StringComparer.OrdinalIgnoreCase);
-
     }
 }


### PR DESCRIPTION
This is kinda what I was thinking. Potential weakness here is that you can only use a simple flat type, otherwise Json.NET will barf trying to re-serialize them to `Dictionary<string, string>`.